### PR TITLE
Remove appends in Map and Repeat

### DIFF
--- a/ops.go
+++ b/ops.go
@@ -42,9 +42,9 @@ func ZeroValue[T any]() T {
 
 // Map calls the function on every array element and returns results in list.
 func Map[T, S any](f func(T) S, arr []T) []S {
-	what := make([]S, 0, len(arr))
-	for _, v := range arr {
-		what = append(what, f(v))
+	what := make([]S, len(arr))
+	for i, v := range arr {
+		what[i] = f(v)
 	}
 	return what
 }
@@ -135,9 +135,9 @@ func Allf[T any](foo func(v T) bool, arr []T) bool {
 
 // Repeat creates a list of given size consisting of the same given value.
 func Repeat[T any](val T, size int) []T {
-	arr := make([]T, 0, size)
-	for i := 0; i < size; i++ {
-		arr = append(arr, val)
+	arr := make([]T, size)
+	for i := range arr {
+		arr[i] = val
 	}
 	return arr
 }


### PR DESCRIPTION
Previously, in `Map` and `Repeat`, new slices were being allocated with an initial length of 0, which was incremented by an `append` every iteration. These functions return a slice of the same size as their input slice, and so there should be no need to `append` at all.

This PR sets the final length of the slice in the `make` call, and then directly indexes the slice in the loop. I've noticed there is much less generated assembly.