### PR TITLE
Correctly implement interpretation of Drop, DropString. Replace old implementation with Skip, SkipString

### DIFF
--- a/ops.go
+++ b/ops.go
@@ -77,12 +77,17 @@ func Tail[T any](num int, arr []T) []T {
 	return arr[len(arr)-num : len(arr)-1]
 }
 
-// Drop drops up to the first `num` elements.
+// Drop allocates a new slice, with the first `num` elements dropped.
 func Drop[T any](num int, arr []T) []T {
 	if len(arr) < num {
 		return []T{}
 	}
-	return arr[num:]
+
+	newLen := len(arr) - num
+	slice := make([]T, 0, newLen)
+	slice = append(slice, arr[num:]...)
+
+	return slice
 }
 
 // DropString drops up to the first `num` runes of a string.

--- a/ops.go
+++ b/ops.go
@@ -90,12 +90,17 @@ func Drop[T any](num int, arr []T) []T {
 	return slice
 }
 
-// DropString drops up to the first `num` runes of a string.
+// DropString allocates a new string, with the first `num` bytes of a string dropped.
 func DropString(num int, what string) string {
 	if len(what) < num {
 		return ""
 	}
-	return what[num:]
+
+	newLen := len(what) - num
+	buffer := make([]byte, 0, newLen)
+	buffer = append(buffer, what[num:]...)
+
+	return string(buffer)
 }
 
 // Any returns true if any element in the list matches the given value.

--- a/ops.go
+++ b/ops.go
@@ -111,6 +111,14 @@ func Skip[T any](num int, arr []T) []T {
 	return arr[num:]
 }
 
+// SkipString skips the first `num` bytes of a string
+func SkipString(num int, what string) string {
+	if len(what) < num {
+		return ""
+	}
+	return what[num:]
+}
+
 // Any returns true if any element in the list matches the given value.
 func Any[T comparable](val T, arr []T) bool {
 	for _, v := range arr {

--- a/ops.go
+++ b/ops.go
@@ -103,6 +103,14 @@ func DropString(num int, what string) string {
 	return string(buffer)
 }
 
+// Skip skips the first `num` elements.
+func Skip[T any](num int, arr []T) []T {
+	if len(arr) < num {
+		return []T{}
+	}
+	return arr[num:]
+}
+
 // Any returns true if any element in the list matches the given value.
 func Any[T comparable](val T, arr []T) bool {
 	for _, v := range arr {


### PR DESCRIPTION
Previously, the doc comment of `Drop` and `DropString` mentioned dropping elements, but in reality it just hid them by shortening the slice, meaning the GC couldn't actually "drop" those elements.

This PR replaces the previous implementation with a new one that copies over anything not dropped to a new slice, allowing the GC to drop the elements that otherwise wouldn't have been. The change in allocation behaviour is outlined in the doc comments.

Considering that users might want to skip without allocating, we add `Skip` and `SkipString`, which performs the same behaviour that `Drop` and `DropString` performed respectively.